### PR TITLE
Integrate Hive Sync with Spark DataSource

### DIFF
--- a/docs/sql_queries.md
+++ b/docs/sql_queries.md
@@ -20,7 +20,7 @@ In the following sections, we cover the configs needed across different query en
 ## Hive
 
 For HiveServer2 access, [install](https://www.cloudera.com/documentation/enterprise/5-6-x/topics/cm_mc_hive_udf.html#concept_nc3_mms_lr)
-the hoodie-hadoop-mr-x.y.z-SNAPSHOT.jar into the aux jars path and we should be able to recognize the Hoodie tables and query them correctly.
+the hoodie-hadoop-mr-bundle-x.y.z-SNAPSHOT.jar into the aux jars path and we should be able to recognize the Hoodie tables and query them correctly.
 
 For beeline access, the `hive.input.format` variable needs to be set to the fully qualified path name of the inputformat `com.uber.hoodie.hadoop.HoodieInputFormat`
 For Tez, additionally the `hive.tez.input.format` needs to be set to `org.apache.hadoop.hive.ql.io.HiveInputFormat`
@@ -39,7 +39,7 @@ However benchmarks have not revealed any real performance degradation with Hoodi
 Sample command is provided below to spin up Spark Shell
 
 ```
-$ spark-shell --jars hoodie-hadoop-mr-x.y.z-SNAPSHOT.jar --driver-class-path /etc/hive/conf  --conf spark.sql.hive.convertMetastoreParquet=false --num-executors 10 --driver-memory 7g --executor-memory 2g  --master yarn-client
+$ spark-shell --jars hoodie-spark-bundle-x.y.z-SNAPSHOT.jar --driver-class-path /etc/hive/conf  --packages com.databricks:spark-avro_2.11:4.0.0 --conf spark.sql.hive.convertMetastoreParquet=false --num-executors 10 --driver-memory 7g --executor-memory 2g  --master yarn-client
 
 scala> sqlContext.sql("select count(*) from uber.trips where datestr = '2016-10-02'").show()
 
@@ -62,7 +62,7 @@ spark.sparkContext.hadoopConfiguration.setClass("mapreduce.input.pathFilter.clas
 
 ## Presto
 
-Presto requires a [patch](https://github.com/prestodb/presto/pull/7002) (until the PR is merged) and the hoodie-hadoop-mr jar to be placed
+Presto requires a [patch](https://github.com/prestodb/presto/pull/7002) (until the PR is merged) and the hoodie-hadoop-mr-bundle jar to be placed
 into `<presto_install>/plugin/hive-hadoop2/`.
 
 {% include callout.html content="Get involved to improve this integration [here](https://github.com/uber/hoodie/issues/81)" type="info" %}

--- a/hoodie-client/pom.xml
+++ b/hoodie-client/pom.xml
@@ -188,12 +188,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-exec</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- Hbase dependencies -->
     <dependency>
         <groupId>org.apache.hbase</groupId>
@@ -223,5 +217,40 @@
             </exclusion>
         </exclusions>
     </dependency>
-    </dependencies>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>hive12</id>
+      <activation>
+        <property>
+          <name>!hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive12.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hive11</id>
+      <activation>
+        <property>
+          <name>hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive11.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+  </profiles>
 </project>

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieCommitMetadata.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieCommitMetadata.java
@@ -329,4 +329,13 @@ public class HoodieCommitMetadata implements Serializable {
     mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
     return mapper;
   }
+
+  @Override
+  public String toString() {
+    return "HoodieCommitMetadata{"
+        + "partitionToWriteStats=" + partitionToWriteStats
+        + ", compacted=" + compacted
+        + ", extraMetadataMap=" + extraMetadataMap
+        + '}';
+  }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/HoodieAvroUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/HoodieAvroUtils.java
@@ -27,9 +27,11 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -137,6 +139,26 @@ public class HoodieAvroUtils {
   }
 
   /**
+   * Add null fields to passed in schema. Caller is responsible for ensuring there is no duplicates.
+   * As different query engines have varying constraints regarding treating the case-sensitivity of fields, its best
+   * to let caller determine that.
+   * @param schema Passed in schema
+   * @param newFieldNames Null Field names to be added
+   * @return
+   */
+  public static Schema appendNullSchemaFields(Schema schema, List<String> newFieldNames) {
+    List<Field> newFields = schema.getFields().stream().map(field -> {
+      return new Schema.Field(field.name(), field.schema(), field.doc(), field.defaultValue());
+    }).collect(Collectors.toList());
+    for (String newField : newFieldNames) {
+      newFields.add(new Schema.Field(newField, METADATA_FIELD_SCHEMA, "", null));
+    }
+    Schema newSchema = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError());
+    newSchema.setFields(newFields);
+    return newSchema;
+  }
+
+  /**
    * Adds the Hoodie commit metadata into the provided Generic Record.
    */
   public static GenericRecord addCommitMetadataToRecord(GenericRecord record, String commitTime,
@@ -155,7 +177,7 @@ public class HoodieAvroUtils {
     for (Schema.Field f : record.getSchema().getFields()) {
       newRecord.put(f.name(), record.get(f.name()));
     }
-    if (!new GenericData().validate(newSchema, newRecord)) {
+    if (!GenericData.get().validate(newSchema, newRecord)) {
       throw new SchemaCompatabilityException(
           "Unable to validate the rewritten record " + record + " against schema "
               + newSchema);

--- a/hoodie-hadoop-mr/pom.xml
+++ b/hoodie-hadoop-mr/pom.xml
@@ -35,7 +35,7 @@
       <groupId>com.uber.hoodie</groupId>
       <artifactId>hoodie-common</artifactId>
       <version>${project.version}</version>
-     <classifier>tests</classifier>
+      <classifier>tests</classifier>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -61,21 +61,12 @@
       <artifactId>hadoop-hdfs</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-exec</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-jdbc</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -116,56 +107,60 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
-              </dependencyReducedPomLocation>
-              <minimizeJar>true</minimizeJar>
-              <relocations>
-                 <relocation>
-                   <pattern>parquet.avro</pattern>
-                   <shadedPattern>hide.parquet.avro</shadedPattern>
-                 </relocation>
-                 <relocation>
-                   <pattern>parquet.column</pattern>
-                   <shadedPattern>hide.parquet.column</shadedPattern>
-                 </relocation>
-                 <relocation>
-                   <pattern>parquet.format.</pattern>
-                   <shadedPattern>hide.parquet.format.</shadedPattern>
-                 </relocation>
-                 <relocation>
-                   <pattern>parquet.hadoop.</pattern>
-                   <shadedPattern>hide.parquet.hadoop.</shadedPattern>
-                 </relocation>
-                 <relocation>
-                   <pattern>parquet.schema</pattern>
-                   <shadedPattern>hide.parquet.schema</shadedPattern>
-                 </relocation>
-              </relocations>
-              <artifactSet>
-                <includes>
-                  <include>com.uber.hoodie:hoodie-common</include>
-                  <include>com.twitter:parquet-avro</include>
-                  <include>com.twitter:parquet-hadoop-bundle</include>
-                  <include>com.twitter.common:objectsize</include>
-                </includes>
-              </artifactSet>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
-
+  <profiles>
+    <profile>
+      <id>hive12</id>
+      <activation>
+        <property>
+          <name>!hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive12.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hive11</id>
+      <activation>
+        <property>
+          <name>hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+       <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive11.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+      </dependencies>
+   </profile>
+  </profiles>
 </project>

--- a/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieROTablePathFilter.java
+++ b/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/HoodieROTablePathFilter.java
@@ -126,7 +126,7 @@ public class HoodieROTablePathFilter implements PathFilter, Serializable {
           HoodieTableMetaClient metaClient = new HoodieTableMetaClient(fs.getConf(),
               baseDir.toString());
           HoodieTableFileSystemView fsView = new HoodieTableFileSystemView(metaClient,
-              metaClient.getActiveTimeline().getCommitTimeline().filterCompletedInstants(),
+              metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants(),
               fs.listStatus(folder));
           List<HoodieDataFile> latestFiles = fsView.getLatestDataFiles()
               .collect(Collectors.toList());

--- a/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/RealtimeCompactedRecordReader.java
+++ b/hoodie-hadoop-mr/src/main/java/com/uber/hoodie/hadoop/realtime/RealtimeCompactedRecordReader.java
@@ -95,8 +95,15 @@ class RealtimeCompactedRecordReader extends AbstractRealtimeRecordReader impleme
         // TODO(NA): Invoke preCombine here by converting arrayWritable to Avro ?
         Writable[] replaceValue = deltaRecordMap.get(key).get();
         Writable[] originalValue = arrayWritable.get();
-        System.arraycopy(replaceValue, 0, originalValue, 0, originalValue.length);
-        arrayWritable.set(originalValue);
+        try {
+          System.arraycopy(replaceValue, 0, originalValue, 0, originalValue.length);
+          arrayWritable.set(originalValue);
+        } catch (RuntimeException re) {
+          LOG.error("Got exception when doing array copy", re);
+          LOG.error("Base record :" + arrayWritableToString(arrayWritable));
+          LOG.error("Log record :" + arrayWritableToString(deltaRecordMap.get(key)));
+          throw re;
+        }
       }
       return true;
     }

--- a/hoodie-hive/run_sync_tool.sh
+++ b/hoodie-hive/run_sync_tool.sh
@@ -14,7 +14,8 @@ if [ -z "${HIVE_HOME}" ]; then
 fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-HOODIE_HIVE_UBER_JAR=`ls $DIR/target/hoodie-hive-*-with-dependencies.jar`
+#Ensure we pick the right jar even for hive11 builds
+HOODIE_HIVE_UBER_JAR=`ls -c $DIR/../packaging/hoodie-hive-bundle/target/hoodie-hive-*.jar | head -1`
 
 if [ -z "$HADOOP_CONF_DIR" ]; then
   echo "setting hadoop conf dir"
@@ -35,4 +36,4 @@ HIVE_JARS=$HIVE_METASTORE:$HIVE_SERVICE:$HIVE_EXEC:$HIVE_SERVICE:$HIVE_JDBC
 HADOOP_HIVE_JARS=${HIVE_JARS}:${HADOOP_HOME}/share/hadoop/common/*:${HADOOP_HOME}/share/hadoop/mapreduce/*:${HADOOP_HOME}/share/hadoop/hdfs/*:${HADOOP_HOME}/share/hadoop/common/lib/*:${HADOOP_HOME}/share/hadoop/hdfs/lib/*
 
 echo "Running Command : java -cp ${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR}:$HOODIE_HIVE_UBER_JAR com.uber.hoodie.hive.HiveSyncTool $@"
-java -cp ${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR}:$HOODIE_HIVE_UBER_JAR com.uber.hoodie.hive.HiveSyncTool "$@"
+java -cp $HOODIE_HIVE_UBER_JAR:${HADOOP_HIVE_JARS}:${HADOOP_CONF_DIR} com.uber.hoodie.hive.HiveSyncTool "$@"

--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/HiveSyncConfig.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/HiveSyncConfig.java
@@ -69,4 +69,20 @@ public class HiveSyncConfig implements Serializable {
 
   @Parameter(names = {"--help", "-h"}, help = true)
   public Boolean help = false;
+
+  @Override
+  public String toString() {
+    return "HiveSyncConfig{"
+        + "databaseName='" + databaseName + '\''
+        + ", tableName='" + tableName + '\''
+        + ", hiveUser='" + hiveUser + '\''
+        + ", hivePass='" + hivePass + '\''
+        + ", jdbcUrl='" + jdbcUrl + '\''
+        + ", basePath='" + basePath + '\''
+        + ", partitionFields=" + partitionFields
+        + ", partitionValueExtractorClass='" + partitionValueExtractorClass + '\''
+        + ", assumeDatePartitioning=" + assumeDatePartitioning
+        + ", help=" + help
+        + '}';
+  }
 }

--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.uber.hoodie.common.model.HoodieCommitMetadata;
+import com.uber.hoodie.common.model.HoodieFileFormat;
 import com.uber.hoodie.common.model.HoodieLogFile;
 import com.uber.hoodie.common.model.HoodieTableType;
 import com.uber.hoodie.common.table.HoodieTableMetaClient;
@@ -34,6 +35,7 @@ import com.uber.hoodie.hive.util.SchemaUtil;
 import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.Driver;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -43,6 +45,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.dbcp.BasicDataSource;
+import org.apache.commons.dbcp.ConnectionFactory;
+import org.apache.commons.dbcp.DriverConnectionFactory;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -185,8 +190,7 @@ public class HoodieHiveClient {
 
       String fullPartitionPath = new Path(syncConfig.basePath, partition).toString();
       String changePartition =
-          alterTable + " PARTITION (" + partBuilder.toString() + ") SET LOCATION '"
-              + "hdfs://nameservice1" + fullPartitionPath + "'";
+          alterTable + " PARTITION (" + partBuilder.toString() + ") SET LOCATION '" + fullPartitionPath + "'";
       changePartitions.add(changePartition);
     }
     return changePartitions;
@@ -234,7 +238,7 @@ public class HoodieHiveClient {
 
   void updateTableDefinition(MessageType newSchema) {
     try {
-      String newSchemaStr = SchemaUtil.generateSchemaString(newSchema);
+      String newSchemaStr = SchemaUtil.generateSchemaString(newSchema, syncConfig.partitionFields);
       // Cascade clause should not be present for non-partitioned tables
       String cascadeClause = syncConfig.partitionFields.size() > 0 ? " cascade" : "";
       StringBuilder sqlBuilder = new StringBuilder("ALTER TABLE ").append("`")
@@ -242,7 +246,7 @@ public class HoodieHiveClient {
           .append(syncConfig.tableName).append("`")
           .append(" REPLACE COLUMNS(").append(newSchemaStr).append(" )")
           .append(cascadeClause);
-      LOG.info("Creating table with " + sqlBuilder);
+      LOG.info("Updating table definition with " + sqlBuilder);
       updateHiveSQL(sqlBuilder.toString());
     } catch (IOException e) {
       throw new HoodieHiveSyncException("Failed to update table for " + syncConfig.tableName, e);
@@ -311,7 +315,8 @@ public class HoodieHiveClient {
           String filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values()
               .stream().findAny().orElseThrow(() -> new IllegalArgumentException(
                   "Could not find any data file written for commit " + lastCommit
-                      + ", could not get schema for dataset " + metaClient.getBasePath()));
+                      + ", could not get schema for dataset " + metaClient.getBasePath()
+                      + ", Metadata :" + commitMetadata));
           return readSchemaFromDataFile(new Path(filePath));
         case MERGE_ON_READ:
           // If this is MOR, depending on whether the latest commit is a delta commit or
@@ -340,12 +345,31 @@ public class HoodieHiveClient {
             // read from the log file wrote
             commitMetadata = HoodieCommitMetadata.fromBytes(
                 activeTimeline.getInstantDetails(lastDeltaInstant).get());
-            filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values()
-                .stream().filter(s -> s.contains(HoodieLogFile.DELTA_EXTENSION))
-                .findAny().orElseThrow(() -> new IllegalArgumentException(
-                    "Could not find any data file written for commit " + lastDeltaInstant
-                        + ", could not get schema for dataset " + metaClient.getBasePath()));
-            return readSchemaFromLogFile(lastCompactionCommit, new Path(filePath));
+            Pair<String, HoodieFileFormat> filePathWithFormat =
+                commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values()
+                    .stream().filter(s -> s.contains(HoodieLogFile.DELTA_EXTENSION))
+                    .findAny().map(f -> Pair.of(f, HoodieFileFormat.HOODIE_LOG))
+                    .orElseGet(() -> {
+                      // No Log files in Delta-Commit. Check if there are any parquet files
+                      return commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream()
+                          .filter(s -> s.contains((metaClient.getTableConfig().getROFileFormat().getFileExtension())))
+                          .findAny()
+                          .map(f -> Pair.of(f, HoodieFileFormat.PARQUET)).orElseThrow(() -> {
+                            return new IllegalArgumentException(
+                                "Could not find any data file written for commit " + lastDeltaInstant
+                                    + ", could not get schema for dataset " + metaClient.getBasePath()
+                                    + ", CommitMetadata :" + commitMetadata);
+                          });
+                    });
+            switch (filePathWithFormat.getRight()) {
+              case HOODIE_LOG:
+                return readSchemaFromLogFile(lastCompactionCommit, new Path(filePathWithFormat.getLeft()));
+              case PARQUET:
+                return readSchemaFromDataFile(new Path(filePathWithFormat.getLeft()));
+              default:
+                throw new IllegalArgumentException("Unknown file format :" + filePathWithFormat.getRight()
+                    + " for file " + filePathWithFormat.getLeft());
+            }
           } else {
             return readSchemaFromLastCompaction(lastCompactionCommit);
           }
@@ -442,14 +466,15 @@ public class HoodieHiveClient {
 
   private void createHiveConnection() {
     if (connection == null) {
-      BasicDataSource ds = new BasicDataSource();
-      ds.setDriverClassName(driverName);
+      BasicDataSource ds = new HiveDataSource();
+      ds.setDriverClassName(HiveDriver.class.getCanonicalName());
       ds.setUrl(getHiveJdbcUrlWithDefaultDBName());
       ds.setUsername(syncConfig.hiveUser);
       ds.setPassword(syncConfig.hivePass);
       LOG.info("Getting Hive Connection from Datasource " + ds);
       try {
         this.connection = ds.getConnection();
+        LOG.info("Successfully got Hive Connection from Datasource " + ds);
       } catch (SQLException e) {
         throw new HoodieHiveSyncException(
             "Cannot create hive connection " + getHiveJdbcUrlWithDefaultDBName(), e);
@@ -587,6 +612,56 @@ public class HoodieHiveClient {
 
     static PartitionEvent newPartitionUpdateEvent(String storagePartition) {
       return new PartitionEvent(PartitionEventType.UPDATE, storagePartition);
+    }
+  }
+
+  /**
+   * There is a bug in BasicDataSource implementation (dbcp-1.4) which does not allow custom version of Driver
+   * (needed to talk to older version of HiveServer2 including CDH-5x). This is fixed in dbcp-2x but we are using
+   * dbcp1.4. Adding a workaround here. TODO: varadarb We need to investigate moving to dbcp-2x
+   */
+  protected class HiveDataSource extends BasicDataSource {
+
+    protected ConnectionFactory createConnectionFactory() throws SQLException {
+      try {
+        Driver driver = HiveDriver.class.newInstance();
+        // Can't test without a validationQuery
+        if (validationQuery == null) {
+          setTestOnBorrow(false);
+          setTestOnReturn(false);
+          setTestWhileIdle(false);
+        }
+
+        // Set up the driver connection factory we will use
+        String user = username;
+        if (user != null) {
+          connectionProperties.put("user", user);
+        } else {
+          log("DBCP DataSource configured without a 'username'");
+        }
+
+        String pwd = password;
+        if (pwd != null) {
+          connectionProperties.put("password", pwd);
+        } else {
+          log("DBCP DataSource configured without a 'password'");
+        }
+
+        ConnectionFactory driverConnectionFactory = new DriverConnectionFactory(driver, url, connectionProperties);
+        return driverConnectionFactory;
+      } catch (Throwable x) {
+        LOG.warn("Got exception trying to instantiate connection factory. Trying default instantiation", x);
+        return super.createConnectionFactory();
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "HiveDataSource{"
+          + "driverClassName='" + driverClassName + '\''
+          + ", driverClassLoader=" + driverClassLoader
+          + ", url='" + url + '\''
+          + '}';
     }
   }
 }

--- a/hoodie-spark/run_hoodie_app.sh
+++ b/hoodie-spark/run_hoodie_app.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+function error_exit {
+    echo "$1" >&2   ## Send message to stderr. Exclude >&2 if you don't want it that way.
+    exit "${2:-1}"  ## Return a code specified by $2 or 1 by default.
+}
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#Ensure we pick the right jar even for hive11 builds
+HOODIE_JAR=`ls -c $DIR/../packaging/hoodie-spark-bundle/target/hoodie-spark-bundle-*.jar | head -1`
+
+if [ -z "$HADOOP_CONF_DIR" ]; then
+  echo "setting hadoop conf dir"
+  HADOOP_CONF_DIR="/etc/hadoop/conf"
+fi
+
+if [ -z "$CLIENT_JAR" ]; then
+  echo "client jar location not set"
+fi
+
+OTHER_JARS=`ls -1 $DIR/target/lib/*jar | grep -v '*avro*-1.' | tr '\n' ':'`
+#TODO - Need to move TestDataGenerator and HoodieJavaApp out of tests
+echo "Running command : java -cp $DIR/target/test-classes/:$DIR/../hoodie-client/target/test-classes/:${HADOOP_CONF_DIR}:$HOODIE_JAR:${CLIENT_JAR}:$OTHER_JARS HoodieJavaApp $@"
+java -cp $DIR/target/test-classes/:$DIR/../hoodie-client/target/test-classes/:${HADOOP_CONF_DIR}:$HOODIE_JAR:${CLIENT_JAR}:$OTHER_JARS HoodieJavaApp "$@"

--- a/hoodie-spark/src/main/java/com/uber/hoodie/DataSourceUtils.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/DataSourceUtils.java
@@ -30,6 +30,8 @@ import com.uber.hoodie.index.HoodieIndex;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
@@ -47,7 +49,8 @@ public class DataSourceUtils {
   public static String getNestedFieldValAsString(GenericRecord record, String fieldName) {
     String[] parts = fieldName.split("\\.");
     GenericRecord valueNode = record;
-    for (int i = 0; i < parts.length; i++) {
+    int i = 0;
+    for (;i < parts.length; i++) {
       String part = parts[i];
       Object val = valueNode.get(part);
       if (val == null) {
@@ -65,7 +68,9 @@ public class DataSourceUtils {
         valueNode = (GenericRecord) val;
       }
     }
-    throw new HoodieException(fieldName + " field not found in record");
+    throw new HoodieException(fieldName + "(Part -" + parts[i] + ") field not found in record. "
+        + "Acceptable fields were :" + valueNode.getSchema().getFields()
+        .stream().map(Field::name).collect(Collectors.toList()));
   }
 
   /**

--- a/hoodie-spark/src/main/scala/com/uber/hoodie/DataSourceOptions.scala
+++ b/hoodie-spark/src/main/scala/com/uber/hoodie/DataSourceOptions.scala
@@ -19,6 +19,7 @@
 package com.uber.hoodie
 
 import com.uber.hoodie.common.model.HoodieTableType
+import com.uber.hoodie.hive.SlashEncodedDayPartitionValueExtractor
 
 /**
   * List of options that can be passed to the Hoodie datasource,
@@ -143,4 +144,28 @@ object DataSourceWriteOptions {
     */
   val COMMIT_METADATA_KEYPREFIX_OPT_KEY = "hoodie.datasource.write.commitmeta.key.prefix"
   val DEFAULT_COMMIT_METADATA_KEYPREFIX_OPT_VAL = "_"
+
+  // HIVE SYNC SPECIFIC CONFIGS
+  //NOTE: DO NOT USE uppercase for the keys as they are internally lower-cased. Using upper-cases causes
+  // unexpected issues with config getting reset
+  val HIVE_SYNC_ENABLED_OPT_KEY = "hoodie.datasource.hive_sync.enable"
+  val HIVE_DATABASE_OPT_KEY = "hoodie.datasource.hive_sync.database"
+  val HIVE_TABLE_OPT_KEY = "hoodie.datasource.hive_sync.table"
+  val HIVE_USER_OPT_KEY = "hoodie.datasource.hive_sync.username"
+  val HIVE_PASS_OPT_KEY = "hoodie.datasource.hive_sync.password"
+  val HIVE_URL_OPT_KEY = "hoodie.datasource.hive_sync.jdbcUrl"
+  val HIVE_PARTITION_FIELDS_OPT_KEY = "hoodie.datasource.hive_sync.partition_fields"
+  val HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY = "hoodie.datasource.hive_sync.partition_extractor_class"
+  val HIVE_ASSUME_DATE_PARTITION_OPT_KEY = "hoodie.datasource.hive_sync.assume_date_partitioning"
+
+  // DEFAULT FOR HIVE SPECIFIC CONFIGS
+  val DEFAULT_HIVE_SYNC_ENABLED_OPT_VAL = "false"
+  val DEFAULT_HIVE_DATABASE_OPT_VAL = "default"
+  val DEFAULT_HIVE_TABLE_OPT_VAL = "unknown"
+  val DEFAULT_HIVE_USER_OPT_VAL = "hive"
+  val DEFAULT_HIVE_PASS_OPT_VAL = "hive"
+  val DEFAULT_HIVE_URL_OPT_VAL = "jdbc:hive2://localhost:10000"
+  val DEFAULT_HIVE_PARTITION_FIELDS_OPT_VAL = ""
+  val DEFAULT_HIVE_PARTITION_EXTRACTOR_CLASS_OPT_VAL = classOf[SlashEncodedDayPartitionValueExtractor].getCanonicalName
+  val DEFAULT_HIVE_ASSUME_DATE_PARTITION_OPT_VAL = "false"
 }

--- a/hoodie-spark/src/main/scala/com/uber/hoodie/DefaultSource.scala
+++ b/hoodie-spark/src/main/scala/com/uber/hoodie/DefaultSource.scala
@@ -25,10 +25,14 @@ import java.util.{Optional, Properties}
 import com.uber.hoodie.DataSourceReadOptions._
 import com.uber.hoodie.DataSourceWriteOptions._
 import com.uber.hoodie.common.table.{HoodieTableConfig, HoodieTableMetaClient}
+import com.uber.hoodie.common.util.FSUtils
 import com.uber.hoodie.config.HoodieWriteConfig
 import com.uber.hoodie.exception.HoodieException
+import com.uber.hoodie.hive.{HiveSyncConfig, HiveSyncTool}
 import org.apache.avro.generic.GenericRecord
 import org.apache.commons.configuration.PropertiesConfiguration
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.hive.conf.HiveConf
 import org.apache.hadoop.fs.Path
 import org.apache.log4j.LogManager
 import org.apache.spark.api.java.JavaSparkContext
@@ -39,6 +43,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 
 import scala.collection.JavaConversions._
+import scala.collection.mutable.ListBuffer
 
 /**
   * Hoodie Spark Datasource, for reading and writing hoodie datasets
@@ -92,6 +97,7 @@ class DefaultSource extends RelationProvider
         classOf[com.uber.hoodie.hadoop.HoodieROTablePathFilter],
         classOf[org.apache.hadoop.fs.PathFilter]);
 
+      log.info("Constructing hoodie (as parquet) data source with options :" + parameters)
       // simply return as a regular parquet relation
       DataSource.apply(
         sparkSession = sqlContext.sparkSession,
@@ -118,6 +124,15 @@ class DefaultSource extends RelationProvider
     defaultsMap.putIfAbsent(PARTITIONPATH_FIELD_OPT_KEY, DEFAULT_PARTITIONPATH_FIELD_OPT_VAL)
     defaultsMap.putIfAbsent(KEYGENERATOR_CLASS_OPT_KEY, DEFAULT_KEYGENERATOR_CLASS_OPT_VAL)
     defaultsMap.putIfAbsent(COMMIT_METADATA_KEYPREFIX_OPT_KEY, DEFAULT_COMMIT_METADATA_KEYPREFIX_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_SYNC_ENABLED_OPT_KEY, DEFAULT_HIVE_SYNC_ENABLED_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_DATABASE_OPT_KEY, DEFAULT_HIVE_DATABASE_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_TABLE_OPT_KEY, DEFAULT_HIVE_TABLE_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_USER_OPT_KEY, DEFAULT_HIVE_USER_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_PASS_OPT_KEY, DEFAULT_HIVE_PASS_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_URL_OPT_KEY, DEFAULT_HIVE_URL_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_PARTITION_FIELDS_OPT_KEY, DEFAULT_HIVE_PARTITION_FIELDS_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY, DEFAULT_HIVE_PARTITION_EXTRACTOR_CLASS_OPT_VAL)
+    defaultsMap.putIfAbsent(HIVE_ASSUME_DATE_PARTITION_OPT_KEY, DEFAULT_HIVE_ASSUME_DATE_PARTITION_OPT_VAL)
     mapAsScalaMap(defaultsMap)
   }
 
@@ -200,7 +215,8 @@ class DefaultSource extends RelationProvider
     }
 
     // Create a HoodieWriteClient & issue the write.
-    val client = DataSourceUtils.createHoodieClient(new JavaSparkContext(sparkContext),
+    val jsc = new JavaSparkContext(sparkContext);
+    val client = DataSourceUtils.createHoodieClient(jsc,
       schema.toString,
       path.get,
       tblName.get,
@@ -228,6 +244,13 @@ class DefaultSource extends RelationProvider
       else {
         log.info("Commit " + commitTime + " failed!")
       }
+
+      val hiveSyncEnabled = parameters.get(HIVE_SYNC_ENABLED_OPT_KEY).map(r => r.toBoolean).getOrElse(false)
+      if (hiveSyncEnabled) {
+        log.info("Syncing to Hive Metastore (URL: " + parameters(HIVE_URL_OPT_KEY) + ")")
+        val fs = FSUtils.getFs(basePath.toString, jsc.hadoopConfiguration)
+        syncHive(basePath, fs, parameters)
+      }
       client.close
     } else {
       log.error(s"Upsert failed with ${errorCount} errors :");
@@ -247,5 +270,28 @@ class DefaultSource extends RelationProvider
     createRelation(sqlContext, parameters, df.schema)
   }
 
+  private def syncHive(basePath: Path, fs: FileSystem, parameters: Map[String, String]): Boolean = {
+    val hiveSyncConfig: HiveSyncConfig = buildSyncConfig(basePath, parameters)
+    val hiveConf: HiveConf = new HiveConf()
+    hiveConf.addResource(fs.getConf)
+    new HiveSyncTool(hiveSyncConfig, hiveConf, fs).syncHoodieTable()
+    true
+  }
+
+  private def buildSyncConfig(basePath: Path, parameters: Map[String, String]): HiveSyncConfig = {
+    val hiveSyncConfig: HiveSyncConfig = new HiveSyncConfig()
+    hiveSyncConfig.basePath = basePath.toString
+    hiveSyncConfig.assumeDatePartitioning =
+      parameters.get(HIVE_ASSUME_DATE_PARTITION_OPT_KEY).exists(r => r.toBoolean)
+    hiveSyncConfig.databaseName = parameters(HIVE_DATABASE_OPT_KEY)
+    hiveSyncConfig.tableName = parameters(HIVE_TABLE_OPT_KEY)
+    hiveSyncConfig.hiveUser = parameters(HIVE_USER_OPT_KEY)
+    hiveSyncConfig.hivePass = parameters(HIVE_PASS_OPT_KEY)
+    hiveSyncConfig.jdbcUrl = parameters(HIVE_URL_OPT_KEY)
+    hiveSyncConfig.partitionFields =
+      ListBuffer(parameters(HIVE_PARTITION_FIELDS_OPT_KEY).split(",").map(_.trim).toList : _*)
+    hiveSyncConfig.partitionValueExtractorClass = parameters(HIVE_PARTITION_EXTRACTOR_CLASS_OPT_KEY)
+    hiveSyncConfig
+  }
   override def shortName(): String = "hoodie"
 }

--- a/hoodie-spark/src/test/java/HoodieJavaApp.java
+++ b/hoodie-spark/src/test/java/HoodieJavaApp.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
@@ -47,6 +48,24 @@ public class HoodieJavaApp {
 
   @Parameter(names = {"--table-type", "-t"}, description = "One of COPY_ON_WRITE or MERGE_ON_READ")
   private String tableType = HoodieTableType.COPY_ON_WRITE.name();
+
+  @Parameter(names = {"--hive-sync", "-hv"}, description = "Enable syncing to hive")
+  private Boolean enableHiveSync = false;
+
+  @Parameter(names = {"--hive-db", "-hd"}, description = "hive database")
+  private String hiveDB = "default";
+
+  @Parameter(names = {"--hive-table", "-ht"}, description = "hive table")
+  private String hiveTable = "hoodie_sample_test";
+
+  @Parameter(names = {"--hive-user", "-hu"}, description = "hive username")
+  private String hiveUser = "hive";
+
+  @Parameter(names = {"--hive-password", "-hp"}, description = "hive password")
+  private String hivePass = "hive";
+
+  @Parameter(names = {"--hive-url", "-hl"}, description = "hive JDBC URL")
+  private String hiveJdbcUrl = "jdbc:hive://localhost:10000";
 
   @Parameter(names = {"--help", "-h"}, help = true)
   public Boolean help = false;
@@ -86,11 +105,12 @@ public class HoodieJavaApp {
     Dataset<Row> inputDF1 = spark.read().json(jssc.parallelize(records1, 2));
 
     // Save as hoodie dataset (copy on write)
-    inputDF1.write().format("com.uber.hoodie") // specify the hoodie source
+    DataFrameWriter<Row> writer = inputDF1.write().format("com.uber.hoodie") // specify the hoodie source
         .option("hoodie.insert.shuffle.parallelism",
             "2") // any hoodie client config can be passed like this
         .option("hoodie.upsert.shuffle.parallelism",
             "2") // full list in HoodieWriteConfig & its package
+        .option(DataSourceWriteOptions.STORAGE_TYPE_OPT_KEY(), tableType) // Hoodie Table Type
         .option(DataSourceWriteOptions.OPERATION_OPT_KEY(),
             DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL()) // insert
         .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(),
@@ -101,9 +121,11 @@ public class HoodieJavaApp {
             "timestamp") // use to combine duplicate records in input/with disk val
         .option(HoodieWriteConfig.TABLE_NAME, tableName) // Used by hive sync and queries
         .mode(
-            SaveMode.Overwrite) // This will remove any existing data at path below, and create a
-        // new dataset if needed
-        .save(tablePath); // ultimately where the dataset will be placed
+            SaveMode.Overwrite); // This will remove any existing data at path below, and create a
+
+    updateHiveSyncConfig(writer);
+    // new dataset if needed
+    writer.save(tablePath); // ultimately where the dataset will be placed
     String commitInstantTime1 = HoodieDataSourceHelpers.latestCommit(fs, tablePath);
     logger.info("First commit at instant time :" + commitInstantTime1);
 
@@ -113,12 +135,15 @@ public class HoodieJavaApp {
     List<String> records2 = DataSourceTestUtils.convertToStringList(
         dataGen.generateUpdates("002"/* ignore */, 100));
     Dataset<Row> inputDF2 = spark.read().json(jssc.parallelize(records2, 2));
-    inputDF2.write().format("com.uber.hoodie").option("hoodie.insert.shuffle.parallelism", "2")
+    writer = inputDF2.write().format("com.uber.hoodie").option("hoodie.insert.shuffle.parallelism", "2")
         .option("hoodie.upsert.shuffle.parallelism", "2")
+        .option(DataSourceWriteOptions.STORAGE_TYPE_OPT_KEY(), tableType) // Hoodie Table Type
         .option(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), "_row_key")
         .option(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), "partition")
         .option(DataSourceWriteOptions.PRECOMBINE_FIELD_OPT_KEY(), "timestamp")
-        .option(HoodieWriteConfig.TABLE_NAME, tableName).mode(SaveMode.Append).save(tablePath);
+        .option(HoodieWriteConfig.TABLE_NAME, tableName).mode(SaveMode.Append);
+    updateHiveSyncConfig(writer);
+    writer.save(tablePath);
     String commitInstantTime2 = HoodieDataSourceHelpers.latestCommit(fs, tablePath);
     logger.info("Second commit at instant time :" + commitInstantTime1);
 
@@ -135,18 +160,39 @@ public class HoodieJavaApp {
     spark.sql("select fare, begin_lon, begin_lat, timestamp from hoodie_ro where fare > 2.0")
         .show();
 
-    /**
-     * Consume incrementally, only changes in commit 2 above.
-     */
-    Dataset<Row> hoodieIncViewDF = spark.read().format("com.uber.hoodie")
-        .option(DataSourceReadOptions.VIEW_TYPE_OPT_KEY(),
-            DataSourceReadOptions.VIEW_TYPE_INCREMENTAL_OPT_VAL())
-        .option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY(),
-            commitInstantTime1) // Only changes in write 2 above
-        .load(
-            tablePath); // For incremental view, pass in the root/base path of dataset
+    if (tableType.equals(HoodieTableType.COPY_ON_WRITE.name())) {
+      /**
+       * Consume incrementally, only changes in commit 2 above. Currently only supported for COPY_ON_WRITE TABLE
+       */
+      Dataset<Row> hoodieIncViewDF = spark.read().format("com.uber.hoodie")
+          .option(DataSourceReadOptions.VIEW_TYPE_OPT_KEY(),
+              DataSourceReadOptions.VIEW_TYPE_INCREMENTAL_OPT_VAL())
+          .option(DataSourceReadOptions.BEGIN_INSTANTTIME_OPT_KEY(),
+              commitInstantTime1) // Only changes in write 2 above
+          .load(
+              tablePath); // For incremental view, pass in the root/base path of dataset
 
-    logger.info("You will only see records from : " + commitInstantTime2);
-    hoodieIncViewDF.groupBy(hoodieIncViewDF.col("_hoodie_commit_time")).count().show();
+      logger.info("You will only see records from : " + commitInstantTime2);
+      hoodieIncViewDF.groupBy(hoodieIncViewDF.col("_hoodie_commit_time")).count().show();
+    }
+  }
+
+  /**
+   * Setup configs for syncing to hive
+   * @param writer
+   * @return
+   */
+  private DataFrameWriter<Row> updateHiveSyncConfig(DataFrameWriter<Row> writer) {
+    if (enableHiveSync) {
+      logger.info("Enabling Hive sync to " + hiveJdbcUrl);
+      writer = writer.option(DataSourceWriteOptions.HIVE_TABLE_OPT_KEY(), hiveTable)
+          .option(DataSourceWriteOptions.HIVE_DATABASE_OPT_KEY(), hiveDB)
+          .option(DataSourceWriteOptions.HIVE_URL_OPT_KEY(), hiveJdbcUrl)
+          .option(DataSourceWriteOptions.HIVE_PARTITION_FIELDS_OPT_KEY(), "dateStr")
+          .option(DataSourceWriteOptions.HIVE_USER_OPT_KEY(), hiveUser)
+          .option(DataSourceWriteOptions.HIVE_PASS_OPT_KEY(), hivePass)
+          .option(DataSourceWriteOptions.HIVE_SYNC_ENABLED_OPT_KEY(), "true");
+    }
+    return writer;
   }
 }

--- a/hoodie-utilities/pom.xml
+++ b/hoodie-utilities/pom.xml
@@ -172,23 +172,8 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-jdbc</artifactId>
-      <version>${hive.version}</version>
-      <classifier>standalone</classifier>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
+ 
     <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
@@ -295,4 +280,58 @@
 
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>hive12</id>
+      <activation>
+        <property>
+          <name>!hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive12.version}</version>
+          <classifier>standalone</classifier>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>javax.servlet</groupId>
+              <artifactId>servlet-api</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hive11</id>
+      <activation>
+        <property>
+          <name>hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive11.version}</version>
+          <classifier>standalone</classifier>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>javax.servlet</groupId>
+              <artifactId>servlet-api</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/packaging/hoodie-hadoop-mr-bundle/pom.xml
+++ b/packaging/hoodie-hadoop-mr-bundle/pom.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~           http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>hoodie</artifactId>
+    <groupId>com.uber.hoodie</groupId>
+    <version>0.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>hoodie-hadoop-mr-bundle</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.uber.hoodie</groupId>
+      <artifactId>hoodie-hadoop-mr</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- other hoodie deps will come from hoodie-hive-bundle -->
+          <groupId>com.uber.hoodie</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-auth</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>parquet-hadoop-bundle</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.twitter.common</groupId>
+      <artifactId>objectsize</artifactId>
+      <version>0.0.12</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
+              </dependencyReducedPomLocation>
+              <relocations>
+                 <relocation>
+                   <pattern>parquet.avro</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.avro</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.column</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.column</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.format.</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.format.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.hadoop.</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.hadoop.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.schema</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.schema</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>org.apache.commons</pattern>
+                   <shadedPattern>com.uber.hoodie.org.apache.commons</shadedPattern>
+                 </relocation>
+              </relocations>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <include>com.uber.hoodie:hoodie-common</include>
+                  <include>com.uber.hoodie:hoodie-hadoop-mr</include>
+                  <include>com.twitter:parquet-avro</include>
+                  <include>com.twitter:parquet-hadoop-bundle</include>
+                  <include>com.twitter.common:objectsize</include>
+                  <include>commons-logging:commons-logging</include>
+                  <include>org.apache.commons:commons-lang3</include>
+                </includes>
+              </artifactSet>
+              <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
+              <classifier>${hiveJarSuffix}</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>hive12</id>
+      <activation>
+        <property>
+          <name>!hive11</name>
+        </property>
+      </activation>
+      <properties>
+        <hiveJarSuffix></hiveJarSuffix>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive12.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-service</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-shims</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+         <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-serde</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-common</artifactId>
+          <version>${hive12.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hive11</id>
+      <activation>
+        <property>
+          <name>hive11</name>
+        </property>
+      </activation>
+      <properties>
+        <hiveJarSuffix>.hive11</hiveJarSuffix>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-service</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-shims</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+       <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive11.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>commons-logging</groupId>
+              <artifactId>commons-logging</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-serde</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-common</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${hive11.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+      </dependencies>
+   </profile>
+  </profiles>
+
+</project>

--- a/packaging/hoodie-hive-bundle/pom.xml
+++ b/packaging/hoodie-hive-bundle/pom.xml
@@ -20,10 +20,11 @@
     <artifactId>hoodie</artifactId>
     <groupId>com.uber.hoodie</groupId>
     <version>0.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>hoodie-hive</artifactId>
+  <artifactId>hoodie-hive-bundle</artifactId>
   <packaging>jar</packaging>
 
   <dependencies>
@@ -94,36 +95,6 @@
       <artifactId>httpclient</artifactId>
     </dependency>
 
-    <!-- Hadoop Testing -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
-      <classifier>tests</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-common</artifactId>
-      <classifier>tests</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-common</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
       <artifactId>parquet-avro</artifactId>
@@ -131,28 +102,22 @@
 
     <dependency>
       <groupId>com.uber.hoodie</groupId>
-      <artifactId>hoodie-hadoop-mr</artifactId>
+      <artifactId>hoodie-hadoop-mr-bundle</artifactId>
       <version>${project.version}</version>
     </dependency>
+ 
     <dependency>
       <groupId>com.uber.hoodie</groupId>
-      <artifactId>hoodie-common</artifactId>
+      <artifactId>hoodie-hive</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- All other hoodie deps will come from hoodie-hadoop-mr-bundle -->
+          <groupId>com.uber.hoodie</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-    <dependency>
-      <groupId>com.uber.hoodie</groupId>
-      <artifactId>hoodie-common</artifactId>
-      <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.esotericsoftware.kryo</groupId>
-      <artifactId>kryo</artifactId>
-      <version>2.21</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>
@@ -163,13 +128,64 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4</version>
         <executions>
           <execution>
+            <phase>package</phase>
             <goals>
-              <goal>test-jar</goal>
+              <goal>shade</goal>
             </goals>
+            <configuration>
+              <relocations>
+                 <relocation>
+                  <pattern>com.beust.</pattern>
+                  <shadedPattern>com.uber.hoodie.com.beust.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                  <pattern>org.joda.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.joda.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                  <pattern>com.google.</pattern>
+                  <shadedPattern>com.uber.hoodie.com.google.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>org.slf4j.</pattern>
+                   <shadedPattern>com.uber.hoodie.org.slf4j.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>org.apache.commons.</pattern>
+                   <shadedPattern>com.uber.hoodie.org.apache.commons.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.column</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.column</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.format.</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.format.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.hadoop.</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.hadoop.</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>parquet.schema.</pattern>
+                   <shadedPattern>com.uber.hoodie.parquet.schema.</shadedPattern>
+                 </relocation>
+              </relocations>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <exclude>log4j:log4j</exclude>
+                  <exclude>org.apache.hadoop:*</exclude>
+                  <exclude>org.apache.hive:*</exclude>
+                  <exclude>org.apache.derby:derby</exclude>
+                </excludes>
+              </artifactSet>
+              <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -184,6 +200,9 @@
           <name>!hive11</name>
         </property>
       </activation>
+      <properties>
+        <hiveJarSuffix></hiveJarSuffix>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>${hive12.groupid}</groupId>
@@ -214,6 +233,9 @@
           <name>hive11</name>
         </property>
       </activation>
+      <properties>
+        <hiveJarSuffix>.hive11</hiveJarSuffix>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>org.apache.hive</groupId>

--- a/packaging/hoodie-spark-bundle/pom.xml
+++ b/packaging/hoodie-spark-bundle/pom.xml
@@ -22,11 +22,12 @@
     <artifactId>hoodie</artifactId>
     <groupId>com.uber.hoodie</groupId>
     <version>0.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.uber.hoodie</groupId>
-  <artifactId>hoodie-spark</artifactId>
+  <artifactId>hoodie-spark-bundle</artifactId>
   <packaging>jar</packaging>
 
   <properties>
@@ -34,31 +35,8 @@
     <junit.version>4.10</junit.version>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>scala-tools.org</id>
-      <name>Scala-tools Maven2 Repository</name>
-      <url>http://scala-tools.org/repo-releases</url>
-    </repository>
-  </repositories>
-
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>net.alchim31.maven</groupId>
-          <artifactId>scala-maven-plugin</artifactId>
-          <version>3.3.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.0.2</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
-    <plugins>
+     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -79,46 +57,130 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>net.alchim31.maven</groupId>
-        <artifactId>scala-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>scala-compile-first</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>add-source</goal>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>scala-test-compile</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-          </execution>
-        </executions>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4</version>
         <executions>
           <execution>
-            <phase>compile</phase>
+            <phase>package</phase>
             <goals>
-              <goal>compile</goal>
+              <goal>shade</goal>
             </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>com.beust.</pattern>
+                  <shadedPattern>com.uber.hoodie.com.beust.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.joda.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.joda.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.</pattern>
+                  <shadedPattern>com.uber.hoodie.com.google.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.slf4j.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.slf4j.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.</shadedPattern>
+                  <excludes>
+                    <exclude>com.databricks.spark.**</exclude>
+                    <exclude>org.apache.avro.**</exclude>
+                    <exclude>org.apache.derby.**</exclude>
+                    <exclude>org.apache.hadoop.**</exclude>
+                    <exclude>org.apache.hive.**</exclude>
+                    <exclude>org.apache.logging.log4j.**</exclude>
+                    <exclude>org.apache.log4j.**</exclude>
+                    <exclude>org.apache.spark.**</exclude>
+                    <exclude>org.apache.thrift.**</exclude>
+                  </excludes>
+                </relocation>
+                <relocation>
+                  <pattern>parquet.column</pattern>
+                  <shadedPattern>com.uber.hoodie.parquet.column</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>parquet.format.</pattern>
+                  <shadedPattern>com.uber.hoodie.parquet.format.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>parquet.hadoop.</pattern>
+                  <shadedPattern>com.uber.hoodie.parquet.hadoop.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>parquet.schema</pattern>
+                  <shadedPattern>com.uber.hoodie.parquet.schema</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hive.jdbc.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hive.jdbc.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop.hive.metastore.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hadoop_hive.metastore.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hive.common.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hive.common.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop.hive.common.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hadoop_hive.common.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop.hive.conf.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hadoop_hive.conf.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hive.service.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hive.service.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop.hive.service.</pattern>
+                  <shadedPattern>com.uber.hoodie.org.apache.hadoop_hive.service.</shadedPattern>
+                </relocation>
+              </relocations>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.databricks:spark-avro_2.11</exclude>
+                  <exclude>log4j:*</exclude>
+                  <exclude>org.apache.avro:*</exclude>
+                  <exclude>org.apache.derby:derby</exclude>
+                  <exclude>org.apache.hadoop:*</exclude>
+                  <exclude>org.apache.hbase:*</exclude>
+                  <!-- Just include hive-common, hive-service, hive-metastore and hive-jdbc -->
+                  <exclude>org.apache.hive:hive-exec</exclude>
+                  <exclude>org.apache.hive:hive-serde</exclude>
+                  <exclude>org.apache.hive:hive-shims</exclude>
+                  <exclude>org.apache.spark:*</exclude>
+                </excludes>
+              </artifactSet>
+              <finalName>${project.artifactId}-${project.version}${hiveJarSuffix}</finalName>
+            </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
 
   <dependencies>
+   <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>jcommander</artifactId>
+   </dependency>
+    <dependency>
+      <groupId>commons-dbcp</groupId>
+      <artifactId>commons-dbcp</artifactId>
+    </dependency>
     <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
@@ -151,7 +213,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
@@ -163,13 +224,11 @@
       </exclusions>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
@@ -179,21 +238,13 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>com.uber.hoodie</groupId>
-      <artifactId>hoodie-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.uber.hoodie</groupId>
@@ -211,28 +262,17 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.uber.hoodie</groupId>
       <artifactId>hoodie-client</artifactId>
       <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
+   </dependency>
     <dependency>
       <groupId>com.uber.hoodie</groupId>
-      <artifactId>hoodie-common</artifactId>
+      <artifactId>hoodie-spark</artifactId>
       <version>${project.version}</version>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
+   </dependency>
   </dependencies>
+
   <profiles>
     <profile>
       <id>hive12</id>
@@ -241,6 +281,9 @@
           <name>!hive11</name>
         </property>
       </activation>
+      <properties>
+        <hiveJarSuffix></hiveJarSuffix>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>${hive12.groupid}</groupId>
@@ -271,6 +314,9 @@
           <name>hive11</name>
         </property>
       </activation>
+      <properties>
+        <hiveJarSuffix>.hive11</hiveJarSuffix>
+      </properties>
       <dependencies>
         <dependency>
           <groupId>${hive11.groupid}</groupId>
@@ -295,5 +341,5 @@
       </dependencies>
     </profile>
   </profiles>
-
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
     <module>hoodie-hive</module>
     <module>hoodie-utilities</module>
     <module>hoodie-spark</module>
+    <module>packaging/hoodie-hadoop-mr-bundle</module>
+    <module>packaging/hoodie-hive-bundle</module>
+    <module>packaging/hoodie-spark-bundle</module>
   </modules>
 
   <licenses>
@@ -109,7 +112,10 @@
     <log4j.version>1.2.17</log4j.version>
     <joda.version>2.9.9</joda.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <hive.version>1.2.1</hive.version>
+    <hive12.groupid>org.apache.hive</hive12.groupid>
+    <hive12.version>1.2.1</hive12.version>
+    <hive11.groupid>org.apache.hive</hive11.groupid>
+    <hive11.version>1.1.1</hive11.version>
     <metrics.version>3.1.1</metrics.version>
     <spark.version>2.1.0</spark.version>
     <avro.version>1.7.7</avro.version>
@@ -405,12 +411,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-common</artifactId>
-        <version>${hive.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
@@ -420,12 +420,6 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-common</artifactId>
         <version>${hadoop.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-exec</artifactId>
-        <version>${hive.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -566,22 +560,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-jdbc</artifactId>
-        <version>${hive.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-service</artifactId>
-        <version>${hive.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.hive</groupId>
-        <artifactId>hive-metastore</artifactId>
-        <version>${hive.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.4</version>
@@ -620,8 +598,11 @@
     </dependencies>
 
   </dependencyManagement>
-
   <repositories>
+    <repository>
+      <id>Maven repository</id>
+      <url>https://central.maven.org/maven2/</url>
+    </repository>
     <repository>
       <id>cloudera-repo-releases</id>
       <url>https://repository.cloudera.com/artifactory/public/</url>
@@ -633,13 +614,116 @@
       <id>ossrh</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
-    <repository>
+   <repository>
       <id>ossrh</id>
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 
   <profiles>
+    <profile>
+      <id>hive12</id>
+      <activation>
+        <property>
+          <name>!hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-service</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-shims</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-serde</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-common</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>${hive12.groupid}</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive12.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>hive11</id>
+      <activation>
+        <property>
+          <name>hive11</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-service</artifactId>
+          <version>${hive11.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-shims</artifactId>
+          <version>${hive11.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-jdbc</artifactId>
+          <version>${hive11.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-serde</artifactId>
+          <version>${hive11.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-metastore</artifactId>
+          <version>${hive11.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-common</artifactId>
+          <version>${hive11.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-exec</artifactId>
+          <version>${hive11.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
     <profile>
       <id>release</id>
       <activation>
@@ -706,7 +790,7 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
+    </profile> 
   </profiles>
 
   <issueManagement>


### PR DESCRIPTION
Hive integration with Spark DataSource works in the following setup

Works on following environments: 
1. Apache Hive 2.3.3 - Apache Spark 2.3.1
2. Apache Hive 1.2.1 - Apache Spark 2.3.1
3. CDH Hive 1.1.0-cdh5.7.2 - Apache Spark 2.3.1

Known Issue: 
   1. https://github.com/uber/hudi/issues/439
   2. With Hoodie compiled against Spark-2.x, the setup does not work with Spark-1.x environment. 

Major Changes: 
  1. Moved all shading to separate modules - packaging/
  2. Bundle jars with shaded dependencies will be generated under packaging/
  3. Integrate Spark Data-Source with Hive Sync 
        (a)  Profiles are used to shade a subset of hive dependencies and packaged along with hoodie-spark-bundle to make DataSource work with older versions of Hive.
        (b) Use mvn package -Dhive11 to build hoodie for older versions of hive. 
  4. Changes to RecordReader to add null fields (corresponding to partition-fields) to projection schema - Needed for working with Hive. Verified it works with both hive and spark. 
  5. Updated Document to reflect the package changes.
  6. Updated HoodieJavaApp to automatically sync using DS. 
